### PR TITLE
Run /run_letsencrypt.py with python2.7, not sh.

### DIFF
--- a/crontab
+++ b/crontab
@@ -1,1 +1,1 @@
-0 3 * * * root sh /run_letsencrypt.py
+0 3 * * * root python2.7 /run_letsencrypt.py


### PR DESCRIPTION
Running it with sh would simply fail, because it's not a shell script.
