### PR TITLE
Add `PATH` to env.sh.

### DIFF
--- a/scripts/run_cron.sh
+++ b/scripts/run_cron.sh
@@ -4,5 +4,6 @@ echo "export DOMAINS=\"$DOMAINS\"" > /var/tmp/env.sh
 echo "export EMAIL=\"$EMAIL\"" >> /var/tmp/env.sh
 echo "export DH_PARAMETERS=\"$DH_PARAMETERS\"" >> /var/tmp/env.sh
 echo "export MERGE_KEY_WITH_CERTIFICATE=\"$MERGE_KEY_WITH_CERTIFICATE\"" >> /var/tmp/env.sh
+echo "export PATH=\"$PATH\"" >> /var/tmp/env.sh
 
 cron -f


### PR DESCRIPTION
Without setting the PATH correctly, /run_letsencrypt.py wouldn't find
the letsencrypt binary.
